### PR TITLE
[FEAT] 게시판 게시글 생성 및 삭제 시 게시글 통계 테이블 생성 및 삭제 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -1,4 +1,8 @@
 package hobbiedo.batch.application;
 
+import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+
 public interface BoardStatsService {
+
+	void createBoardStats(BoardCreateEventDto eventDto);
 }

--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -1,0 +1,4 @@
+package hobbiedo.batch.application;
+
+public interface BoardStatsService {
+}

--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -1,8 +1,11 @@
 package hobbiedo.batch.application;
 
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
 
 public interface BoardStatsService {
 
 	void createBoardStats(BoardCreateEventDto eventDto);
+
+	void deleteBoardStats(BoardDeleteEventDto eventDto);
 }

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import hobbiedo.batch.domain.BoardStats;
 import hobbiedo.batch.infrastructure.BoardStatsRepository;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,6 +35,23 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 				.build();
 
 			boardStatsRepository.save(boardStats);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * 게시글 통계 삭제
+	 * @param eventDto
+	 */
+	@Override
+	@Transactional
+	public void deleteBoardStats(BoardDeleteEventDto eventDto) {
+
+		try {
+
+			boardStatsRepository.deleteByBoardId(eventDto.getBoardId());
 		} catch (Exception e) {
 
 			e.printStackTrace();

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -30,8 +30,8 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 
 			BoardStats boardStats = BoardStats.builder()
 				.boardId(eventDto.getBoardId())
-				.commentCount(0L)
-				.likeCount(0L)
+				.commentCount(0)
+				.likeCount(0)
 				.build();
 
 			boardStatsRepository.save(boardStats);

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -1,0 +1,42 @@
+package hobbiedo.batch.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hobbiedo.batch.domain.BoardStats;
+import hobbiedo.batch.infrastructure.BoardStatsRepository;
+import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardStatsServiceImpl implements BoardStatsService {
+
+	private final BoardStatsRepository boardStatsRepository;
+
+	/**
+	 * 게시글 통계 생성
+	 * @param eventDto
+	 */
+	@Override
+	@Transactional
+	public void createBoardStats(BoardCreateEventDto eventDto) {
+
+		try {
+
+			BoardStats boardStats = BoardStats.builder()
+				.boardId(eventDto.getBoardId())
+				.commentCount(0L)
+				.likeCount(0L)
+				.build();
+
+			boardStatsRepository.save(boardStats);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/hobbiedo/batch/domain/BoardStats.java
+++ b/src/main/java/hobbiedo/batch/domain/BoardStats.java
@@ -1,0 +1,43 @@
+package hobbiedo.batch.domain;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import hobbiedo.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardStats extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Long boardId;
+
+	@Column(nullable = false)
+	@ColumnDefault("0")
+	private Long likeCount;
+
+	@Column(nullable = false)
+	@ColumnDefault("0")
+	private Long commentCount;
+
+	@Builder
+	public BoardStats(Long boardId, Long likeCount, Long commentCount) {
+		this.boardId = boardId;
+		this.likeCount = likeCount;
+		this.commentCount = commentCount;
+	}
+}

--- a/src/main/java/hobbiedo/batch/domain/BoardStats.java
+++ b/src/main/java/hobbiedo/batch/domain/BoardStats.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,14 +27,14 @@ public class BoardStats extends BaseEntity {
 
 	@Column(nullable = false)
 	@ColumnDefault("0")
-	private Long likeCount;
+	private Integer likeCount;
 
 	@Column(nullable = false)
 	@ColumnDefault("0")
-	private Long commentCount;
+	private Integer commentCount;
 
 	@Builder
-	public BoardStats(Long boardId, Long likeCount, Long commentCount) {
+	public BoardStats(Long boardId, Integer likeCount, Integer commentCount) {
 		this.boardId = boardId;
 		this.likeCount = likeCount;
 		this.commentCount = commentCount;

--- a/src/main/java/hobbiedo/batch/infrastructure/BoardStatsRepository.java
+++ b/src/main/java/hobbiedo/batch/infrastructure/BoardStatsRepository.java
@@ -1,0 +1,12 @@
+package hobbiedo.batch.infrastructure;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import hobbiedo.batch.domain.BoardStats;
+
+@Repository
+public interface BoardStatsRepository extends JpaRepository<BoardStats, Long> {
+}

--- a/src/main/java/hobbiedo/batch/infrastructure/BoardStatsRepository.java
+++ b/src/main/java/hobbiedo/batch/infrastructure/BoardStatsRepository.java
@@ -1,7 +1,5 @@
 package hobbiedo.batch.infrastructure;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +7,7 @@ import hobbiedo.batch.domain.BoardStats;
 
 @Repository
 public interface BoardStatsRepository extends JpaRepository<BoardStats, Long> {
+
+	// 게시글 통계 삭제
+	void deleteByBoardId(Long boardId);
 }

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 
 import hobbiedo.batch.application.BoardStatsService;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -13,10 +14,25 @@ public class KafkaConsumerService {
 
 	private final BoardStatsService boardStatsService;
 
+	/**
+	 * 게시글 생성 이벤트 수신
+	 * @param eventDto
+	 */
 	@KafkaListener(topics = "board-create-topic", groupId = "${spring.kafka.consumer.group-id}",
-		containerFactory = "kafkaListenerContainerFactory")
+		containerFactory = "createKafkaListenerContainerFactory")
 	public void listenToBoardCreateTopic(BoardCreateEventDto eventDto) {
 
 		boardStatsService.createBoardStats(eventDto);
+	}
+
+	/**
+	 * 게시글 삭제 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "deleteKafkaListenerContainerFactory")
+	public void listenToBoardDeleteTopic(BoardDeleteEventDto eventDto) {
+
+		boardStatsService.deleteBoardStats(eventDto);
 	}
 }

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
@@ -1,0 +1,22 @@
+package hobbiedo.batch.kafka.application;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import hobbiedo.batch.application.BoardStatsService;
+import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumerService {
+
+	private final BoardStatsService boardStatsService;
+
+	@KafkaListener(topics = "board-create-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "kafkaListenerContainerFactory")
+	public void listenToBoardCreateTopic(BoardCreateEventDto eventDto) {
+
+		boardStatsService.createBoardStats(eventDto);
+	}
+}

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardCreateEventDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardCreateEventDto.java
@@ -1,0 +1,13 @@
+package hobbiedo.batch.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCreateEventDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardDeleteEventDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardDeleteEventDto.java
@@ -1,0 +1,13 @@
+package hobbiedo.batch.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDeleteEventDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
@@ -1,0 +1,42 @@
+package hobbiedo.global.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	@Bean
+	public ConsumerFactory<String, String> consumerFactory() {
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		return new DefaultKafkaConsumerFactory<>(configProps);
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory());
+		return factory;
+	}
+}

--- a/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
@@ -15,6 +15,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -33,7 +34,8 @@ public class KafkaConsumerConfig {
 	 * @return ConsumerFactory<String, BoardCreateEventDto>
 	 */
 	@Bean
-	public ConsumerFactory<String, BoardCreateEventDto> consumerFactory() {
+	public ConsumerFactory<String, BoardCreateEventDto> createConsumerFactory() {
+
 		Map<String, Object> configProps = new HashMap<>();
 		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
@@ -46,10 +48,42 @@ public class KafkaConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> kafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> createKafkaListenerContainerFactory() {
+
 		ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
-		factory.setConsumerFactory(consumerFactory());
+
+		factory.setConsumerFactory(createConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 통계 테이블 삭제 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardDeleteEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardDeleteEventDto> deleteConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardDeleteEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> deleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(deleteConsumerFactory());
+
 		return factory;
 	}
 }

--- a/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
@@ -12,9 +12,14 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableKafka
+@RequiredArgsConstructor
 public class KafkaConsumerConfig {
 
 	@Value("${spring.kafka.bootstrap-servers}")
@@ -23,19 +28,27 @@ public class KafkaConsumerConfig {
 	@Value("${spring.kafka.consumer.group-id}")
 	private String groupId;
 
+	/**
+	 * 게시글 통계 테이블 생성 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCreateEventDto>
+	 */
 	@Bean
-	public ConsumerFactory<String, String> consumerFactory() {
+	public ConsumerFactory<String, BoardCreateEventDto> consumerFactory() {
 		Map<String, Object> configProps = new HashMap<>();
 		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		return new DefaultKafkaConsumerFactory<>(configProps);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCreateEventDto.class, false));
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
-		ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
 		factory.setConsumerFactory(consumerFactory());
 		return factory;
 	}


### PR DESCRIPTION
## 📣 [FEAT] 게시판 게시글 생성 및 삭제 시 게시글 통계 테이블 생성 및 삭제 기능 추가
### 📅 날짜 -  2024.06.15

### 🌵Branch
feature/create-and-delete-board-stats-table  → develop

### 📢 Description
**게시글 서비스에서 게시글 생성 삭제가 되면서 발송한 토픽 메세지를 감지하여 해당 토픽을 판단하고, 담겨진 데이터 속 게시글 id 를 의존하는 게시글 통계 테이블을 생성 및 삭제한다**

### 💬Issue Number
[#1 ] - 💫[FEAT] 게시판 게시글 생성 및 삭제 시 게시글 통계 테이블 생성 및 삭제 기능 추가 #1

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 컨슈머 설정을 해주었고, 로컬에서 swagger 를 통해 게시글 생성 삭제시 통계 테이블이 같이 생성 삭제되는 것을 확인하였다
2. 추후 받은 데이터에 대한 예외처리를 해줄 사항이 있는 지 검토 후 리펙토링을 해줄 예정이다
3. 게시판 서비스와 마찬가지로 새로 할당받은 인스턴스 내 카프카 서버를 의존케 하였다