### PR TITLE
[FEAT] 게시글 댓글, 좋아요 업데이트 토픽 수신 시 통계 테이블 업데이트 기능 추가 및 댓글, 좋아요 수 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,72 +1,75 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.6'
-	id 'io.spring.dependency-management' version '1.1.5'
-	id 'checkstyle'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.6'
+    id 'io.spring.dependency-management' version '1.1.5'
+    id 'checkstyle'
 }
 
 group = 'hobbiedo'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 checkstyle {
-	maxWarnings = 0 // 규칙이 어긋나는 코드가 하나라도 있을 경우 빌드 fail을 내고 싶다면 이 선언을 추가한다.
-	configFile = rootProject.file("${rootDir}/naver-checkstyle-rules.xml")
-	configProperties = ["suppressionFile": "${rootDir}/naver-checkstyle-suppressions.xml"]
-	toolVersion = '8.29' // checkstyle 버전 8.24 이상 선언
-	sourceSets = [sourceSets.main]
+    maxWarnings = 0 // 규칙이 어긋나는 코드가 하나라도 있을 경우 빌드 fail을 내고 싶다면 이 선언을 추가한다.
+    configFile = rootProject.file("${rootDir}/naver-checkstyle-rules.xml")
+    configProperties = ["suppressionFile": "${rootDir}/naver-checkstyle-suppressions.xml"]
+    toolVersion = '8.29' // checkstyle 버전 8.24 이상 선언
+    sourceSets = [sourceSets.main]
 }
 
 checkstyleMain {
-	source = fileTree('/src/main/java')
+    source = fileTree('/src/main/java')
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2023.0.2")
+    set('springCloudVersion', "2023.0.2")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-batch'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.kafka:spring-kafka'
 
-	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    // scheduler
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
 
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.batch:spring-batch-test'
-	testImplementation 'org.springframework.kafka:spring-kafka-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -1,5 +1,6 @@
 package hobbiedo.batch.application;
 
+import hobbiedo.batch.dto.response.BoardStatsResponseDto;
 import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
@@ -14,4 +15,6 @@ public interface BoardStatsService {
 	void updateBoardCommentStats(BoardCommentUpdateDto eventDto);
 
 	void updateBoardLikeStats(BoardLikeUpdateDto eventDto);
+
+	BoardStatsResponseDto getBoardStats(Long boardId);
 }

--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -14,7 +14,11 @@ public interface BoardStatsService {
 
 	void updateBoardCommentStats(BoardCommentUpdateDto eventDto);
 
+	void deleteBoardCommentStats(BoardCommentUpdateDto eventDto);
+
 	void updateBoardLikeStats(BoardLikeUpdateDto eventDto);
+
+	void deleteBoardLikeStats(BoardLikeUpdateDto eventDto);
 
 	BoardStatsResponseDto getBoardStats(Long boardId);
 }

--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -1,11 +1,17 @@
 package hobbiedo.batch.application;
 
+import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.batch.kafka.dto.BoardLikeUpdateDto;
 
 public interface BoardStatsService {
 
 	void createBoardStats(BoardCreateEventDto eventDto);
 
 	void deleteBoardStats(BoardDeleteEventDto eventDto);
+
+	void updateBoardCommentStats(BoardCommentUpdateDto eventDto);
+
+	void updateBoardLikeStats(BoardLikeUpdateDto eventDto);
 }

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -77,6 +77,7 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 
 		boardStatsRepository.save(
 			BoardStats.builder()
+				.id(boardStats.getId())
 				.boardId(eventDto.getBoardId())
 				.commentCount(boardStats.getCommentCount() + eventDto.getCommentCount())
 				.likeCount(boardStats.getLikeCount())
@@ -98,6 +99,7 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 
 		boardStatsRepository.save(
 			BoardStats.builder()
+				.id(boardStats.getId())
 				.boardId(eventDto.getBoardId())
 				.commentCount(boardStats.getCommentCount())
 				.likeCount(boardStats.getLikeCount() + eventDto.getLikeCount())

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -66,7 +66,6 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 
 	/**
 	 * 게시글 통계 댓글 수 업데이트
-	 * 댓글 수는 증가 또는 감소 가능
 	 * @param eventDto
 	 */
 	@Override
@@ -80,7 +79,28 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 			BoardStats.builder()
 				.id(boardStats.getId())
 				.boardId(eventDto.getBoardId())
-				.commentCount(boardStats.getCommentCount() + eventDto.getCommentCount())
+				.commentCount(boardStats.getCommentCount() + 1)
+				.likeCount(boardStats.getLikeCount())
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 통계 댓글 수 삭제
+	 * @param eventDto
+	 */
+	@Override
+	@Transactional
+	public void deleteBoardCommentStats(BoardCommentUpdateDto eventDto) {
+
+		BoardStats boardStats = boardStatsRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new BatchExceptionHandler(BOARD_STATS_NOT_FOUND));
+
+		boardStatsRepository.save(
+			BoardStats.builder()
+				.id(boardStats.getId())
+				.boardId(eventDto.getBoardId())
+				.commentCount(boardStats.getCommentCount() - 1)
 				.likeCount(boardStats.getLikeCount())
 				.build()
 		);
@@ -88,7 +108,6 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 
 	/**
 	 * 게시글 통계 좋아요 수 업데이트
-	 * 좋아요 수는 증가 또는 감소 가능
 	 * @param eventDto
 	 */
 	@Override
@@ -103,7 +122,28 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 				.id(boardStats.getId())
 				.boardId(eventDto.getBoardId())
 				.commentCount(boardStats.getCommentCount())
-				.likeCount(boardStats.getLikeCount() + eventDto.getLikeCount())
+				.likeCount(boardStats.getLikeCount() + 1)
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 통계 좋아요 수 삭제
+	 * @param eventDto
+	 */
+	@Override
+	@Transactional
+	public void deleteBoardLikeStats(BoardLikeUpdateDto eventDto) {
+
+		BoardStats boardStats = boardStatsRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new BatchExceptionHandler(BOARD_STATS_NOT_FOUND));
+
+		boardStatsRepository.save(
+			BoardStats.builder()
+				.id(boardStats.getId())
+				.boardId(eventDto.getBoardId())
+				.commentCount(boardStats.getCommentCount())
+				.likeCount(boardStats.getLikeCount() - 1)
 				.build()
 		);
 	}

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hobbiedo.batch.domain.BoardStats;
+import hobbiedo.batch.dto.response.BoardStatsResponseDto;
 import hobbiedo.batch.infrastructure.BoardStatsRepository;
 import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
@@ -105,5 +106,22 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 				.likeCount(boardStats.getLikeCount() + eventDto.getLikeCount())
 				.build()
 		);
+	}
+
+	/**
+	 * 게시글 통계 조회
+	 * @param boardId
+	 * @return
+	 */
+	@Override
+	public BoardStatsResponseDto getBoardStats(Long boardId) {
+
+		BoardStats boardStats = boardStatsRepository.findByBoardId(boardId)
+			.orElseThrow(() -> new BatchExceptionHandler(BOARD_STATS_NOT_FOUND));
+
+		return BoardStatsResponseDto.builder()
+			.commentCount(boardStats.getCommentCount())
+			.likeCount(boardStats.getLikeCount())
+			.build();
 	}
 }

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -1,12 +1,17 @@
 package hobbiedo.batch.application;
 
+import static hobbiedo.global.api.code.status.ErrorStatus.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hobbiedo.batch.domain.BoardStats;
 import hobbiedo.batch.infrastructure.BoardStatsRepository;
+import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.batch.kafka.dto.BoardLikeUpdateDto;
+import hobbiedo.global.api.exception.handler.BatchExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,5 +61,47 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 
 			e.printStackTrace();
 		}
+	}
+
+	/**
+	 * 게시글 통계 댓글 수 업데이트
+	 * 댓글 수는 증가 또는 감소 가능
+	 * @param eventDto
+	 */
+	@Override
+	@Transactional
+	public void updateBoardCommentStats(BoardCommentUpdateDto eventDto) {
+
+		BoardStats boardStats = boardStatsRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new BatchExceptionHandler(BOARD_STATS_NOT_FOUND));
+
+		boardStatsRepository.save(
+			BoardStats.builder()
+				.boardId(eventDto.getBoardId())
+				.commentCount(boardStats.getCommentCount() + eventDto.getCommentCount())
+				.likeCount(boardStats.getLikeCount())
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 통계 좋아요 수 업데이트
+	 * 좋아요 수는 증가 또는 감소 가능
+	 * @param eventDto
+	 */
+	@Override
+	@Transactional
+	public void updateBoardLikeStats(BoardLikeUpdateDto eventDto) {
+
+		BoardStats boardStats = boardStatsRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new BatchExceptionHandler(BOARD_STATS_NOT_FOUND));
+
+		boardStatsRepository.save(
+			BoardStats.builder()
+				.boardId(eventDto.getBoardId())
+				.commentCount(boardStats.getCommentCount())
+				.likeCount(boardStats.getLikeCount() + eventDto.getLikeCount())
+				.build()
+		);
 	}
 }

--- a/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsProcessor.java
+++ b/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsProcessor.java
@@ -1,0 +1,11 @@
+package hobbiedo.batch.batchscheduled;
+
+import hobbiedo.batch.domain.BoardStats;
+
+public class BoardStatsProcessor {
+
+	public BoardStats process(BoardStats item) {
+		// 데이터 처리 로직 구현
+		return item;
+	}
+}

--- a/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsReader.java
+++ b/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsReader.java
@@ -1,0 +1,23 @@
+package hobbiedo.batch.batchscheduled;
+
+import java.util.List;
+
+import hobbiedo.batch.domain.BoardStats;
+
+public class BoardStatsReader {
+
+	private final List<BoardStats> data;
+	private int nextIndex;
+
+	public BoardStatsReader(List<BoardStats> data) {
+		this.data = data;
+		this.nextIndex = 0;
+	}
+
+	public BoardStats read() {
+		if (nextIndex < data.size()) {
+			return data.get(nextIndex++);
+		}
+		return null;
+	}
+}

--- a/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsTasklet.java
+++ b/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsTasklet.java
@@ -1,0 +1,22 @@
+package hobbiedo.batch.batchscheduled;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BoardStatsTasklet /*implements Tasklet*/ {
+
+	private final BoardStatsReader reader;
+	private final BoardStatsProcessor processor;
+	private final BoardStatsWriter writer;
+
+	// @Override
+	// public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws
+	// 	Exception {
+	// 	BoardStats item;
+	// 	while ((item = reader.read()) != null) {
+	// 		BoardStats processedItem = processor.process(item);
+	// 		writer.write(processedItem);
+	// 	}
+	// 	return RepeatStatus.FINISHED;
+	// }
+}

--- a/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsWriter.java
+++ b/src/main/java/hobbiedo/batch/batchscheduled/BoardStatsWriter.java
@@ -1,0 +1,15 @@
+package hobbiedo.batch.batchscheduled;
+
+import hobbiedo.batch.application.BoardStatsService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BoardStatsWriter {
+
+	private final BoardStatsService boardStatsService;
+
+	// public void write(BoardStats item) {
+	// 데이터 저장 로직 구현
+	// 	boardStatsService.updateBoardStats(item);
+	// }
+}

--- a/src/main/java/hobbiedo/batch/batchscheduled/ScheduledTasks.java
+++ b/src/main/java/hobbiedo/batch/batchscheduled/ScheduledTasks.java
@@ -1,0 +1,4 @@
+package hobbiedo.batch.batchscheduled;
+
+public class ScheduledTasks {
+}

--- a/src/main/java/hobbiedo/batch/domain/BoardStats.java
+++ b/src/main/java/hobbiedo/batch/domain/BoardStats.java
@@ -34,7 +34,8 @@ public class BoardStats extends BaseEntity {
 	private Integer commentCount;
 
 	@Builder
-	public BoardStats(Long boardId, Integer likeCount, Integer commentCount) {
+	public BoardStats(Long id, Long boardId, Integer likeCount, Integer commentCount) {
+		this.id = id;
 		this.boardId = boardId;
 		this.likeCount = likeCount;
 		this.commentCount = commentCount;

--- a/src/main/java/hobbiedo/batch/dto/response/BoardStatsResponseDto.java
+++ b/src/main/java/hobbiedo/batch/dto/response/BoardStatsResponseDto.java
@@ -1,0 +1,16 @@
+package hobbiedo.batch.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardStatsResponseDto {
+
+	private Integer commentCount; // 댓글 수
+	private Integer likeCount; // 좋아요 수
+}

--- a/src/main/java/hobbiedo/batch/infrastructure/BoardStatsRepository.java
+++ b/src/main/java/hobbiedo/batch/infrastructure/BoardStatsRepository.java
@@ -1,5 +1,7 @@
 package hobbiedo.batch.infrastructure;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,6 @@ public interface BoardStatsRepository extends JpaRepository<BoardStats, Long> {
 
 	// 게시글 통계 삭제
 	void deleteByBoardId(Long boardId);
+
+	Optional<BoardStats> findByBoardId(Long boardId);
 }

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
@@ -46,12 +46,7 @@ public class KafkaConsumerService {
 		containerFactory = "commentUpdateKafkaListenerContainerFactory")
 	public void listenToBoardCommentUpdateTopic(BoardCommentUpdateDto eventDto) {
 
-		boardStatsService.updateBoardCommentStats(
-			BoardCommentUpdateDto.builder()
-				.boardId(eventDto.getBoardId())
-				.commentCount(eventDto.getCommentCount() + 1)
-				.build()
-		);
+		boardStatsService.updateBoardCommentStats(eventDto);
 	}
 
 	/**
@@ -62,12 +57,7 @@ public class KafkaConsumerService {
 		containerFactory = "commentDeleteKafkaListenerContainerFactory")
 	public void listenToBoardCommentDeleteTopic(BoardCommentUpdateDto eventDto) {
 
-		boardStatsService.updateBoardCommentStats(
-			BoardCommentUpdateDto.builder()
-				.boardId(eventDto.getBoardId())
-				.commentCount(eventDto.getCommentCount() - 1)
-				.build()
-		);
+		boardStatsService.deleteBoardCommentStats(eventDto);
 	}
 
 	/**
@@ -78,12 +68,7 @@ public class KafkaConsumerService {
 		containerFactory = "likeUpdateKafkaListenerContainerFactory")
 	public void listenToBoardLikeUpdateTopic(BoardLikeUpdateDto eventDto) {
 
-		boardStatsService.updateBoardLikeStats(
-			BoardLikeUpdateDto.builder()
-				.boardId(eventDto.getBoardId())
-				.likeCount(eventDto.getLikeCount() + 1)
-				.build()
-		);
+		boardStatsService.updateBoardLikeStats(eventDto);
 	}
 
 	/**
@@ -94,11 +79,6 @@ public class KafkaConsumerService {
 		containerFactory = "likeDeleteKafkaListenerContainerFactory")
 	public void listenToBoardLikeDeleteTopic(BoardLikeUpdateDto eventDto) {
 
-		boardStatsService.updateBoardLikeStats(
-			BoardLikeUpdateDto.builder()
-				.boardId(eventDto.getBoardId())
-				.likeCount(eventDto.getLikeCount() - 1)
-				.build()
-		);
+		boardStatsService.deleteBoardLikeStats(eventDto);
 	}
 }

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
@@ -46,6 +46,12 @@ public class KafkaConsumerService {
 		containerFactory = "commentUpdateKafkaListenerContainerFactory")
 	public void listenToBoardCommentUpdateTopic(BoardCommentUpdateDto eventDto) {
 
+		boardStatsService.updateBoardCommentStats(
+			BoardCommentUpdateDto.builder()
+				.boardId(eventDto.getBoardId())
+				.commentCount(eventDto.getCommentCount() + 1)
+				.build()
+		);
 	}
 
 	/**
@@ -56,6 +62,12 @@ public class KafkaConsumerService {
 		containerFactory = "commentDeleteKafkaListenerContainerFactory")
 	public void listenToBoardCommentDeleteTopic(BoardCommentUpdateDto eventDto) {
 
+		boardStatsService.updateBoardCommentStats(
+			BoardCommentUpdateDto.builder()
+				.boardId(eventDto.getBoardId())
+				.commentCount(eventDto.getCommentCount() - 1)
+				.build()
+		);
 	}
 
 	/**
@@ -66,6 +78,12 @@ public class KafkaConsumerService {
 		containerFactory = "likeUpdateKafkaListenerContainerFactory")
 	public void listenToBoardLikeUpdateTopic(BoardLikeUpdateDto eventDto) {
 
+		boardStatsService.updateBoardLikeStats(
+			BoardLikeUpdateDto.builder()
+				.boardId(eventDto.getBoardId())
+				.likeCount(eventDto.getLikeCount() + 1)
+				.build()
+		);
 	}
 
 	/**
@@ -76,5 +94,11 @@ public class KafkaConsumerService {
 		containerFactory = "likeDeleteKafkaListenerContainerFactory")
 	public void listenToBoardLikeDeleteTopic(BoardLikeUpdateDto eventDto) {
 
+		boardStatsService.updateBoardLikeStats(
+			BoardLikeUpdateDto.builder()
+				.boardId(eventDto.getBoardId())
+				.likeCount(eventDto.getLikeCount() - 1)
+				.build()
+		);
 	}
 }

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
@@ -4,8 +4,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import hobbiedo.batch.application.BoardStatsService;
+import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.batch.kafka.dto.BoardLikeUpdateDto;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -34,5 +36,45 @@ public class KafkaConsumerService {
 	public void listenToBoardDeleteTopic(BoardDeleteEventDto eventDto) {
 
 		boardStatsService.deleteBoardStats(eventDto);
+	}
+
+	/**
+	 * 게시글 댓글 수 증가 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-comment-update-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "commentUpdateKafkaListenerContainerFactory")
+	public void listenToBoardCommentUpdateTopic(BoardCommentUpdateDto eventDto) {
+
+	}
+
+	/**
+	 * 게시글 댓글 수 감소 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-comment-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "commentDeleteKafkaListenerContainerFactory")
+	public void listenToBoardCommentDeleteTopic(BoardCommentUpdateDto eventDto) {
+
+	}
+
+	/**
+	 * 게시글 좋아요 수 증가 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-like-update-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "likeUpdateKafkaListenerContainerFactory")
+	public void listenToBoardLikeUpdateTopic(BoardLikeUpdateDto eventDto) {
+
+	}
+
+	/**
+	 * 게시글 좋아요 수 감소 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-like-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "likeDeleteKafkaListenerContainerFactory")
+	public void listenToBoardLikeDeleteTopic(BoardLikeUpdateDto eventDto) {
+
 	}
 }

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 public class BoardCommentUpdateDto {
 
 	private Long boardId;
-	private Integer commentCount;
+	private Integer commentCount = 0;
 }

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 public class BoardCommentUpdateDto {
 
 	private Long boardId;
-	private Integer commentCount = 0;
+	private Integer commentCount;
 }

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class BoardCommentUpdateDto {
 
 	private Long boardId;
+	private Integer commentCount;
 }

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardCommentUpdateDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.batch.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCommentUpdateDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 public class BoardLikeUpdateDto {
 
 	private Long boardId;
-	private Integer likeCount = 0;
+	private Integer likeCount;
 }

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class BoardLikeUpdateDto {
 
 	private Long boardId;
+	private Integer likeCount;
 }

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.batch.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardLikeUpdateDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/BoardLikeUpdateDto.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 public class BoardLikeUpdateDto {
 
 	private Long boardId;
-	private Integer likeCount;
+	private Integer likeCount = 0;
 }

--- a/src/main/java/hobbiedo/batch/presentation/BoardStatsController.java
+++ b/src/main/java/hobbiedo/batch/presentation/BoardStatsController.java
@@ -1,0 +1,40 @@
+package hobbiedo.batch.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hobbiedo.batch.application.BoardStatsService;
+import hobbiedo.batch.dto.response.BoardStatsResponseDto;
+import hobbiedo.batch.vo.response.BoardStatsResponseVo;
+import hobbiedo.global.api.ApiResponse;
+import hobbiedo.global.api.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/users/crew/board-stats")
+@Tag(name = "BoardStats", description = "게시글 통계 서비스")
+public class BoardStatsController {
+
+	private final BoardStatsService boardStatsService;
+
+	// 게시글 통계 조회
+	@GetMapping("/{boardId}/stats")
+	@Operation(summary = "게시글 통계 조회", description = "게시글의 댓글 수와 좋아요 수를 조회합니다.")
+	public ApiResponse<BoardStatsResponseVo> getBoardStats(
+		@PathVariable("boardId") Long boardId) {
+
+		BoardStatsResponseDto boardStatsResponseDto = boardStatsService.getBoardStats(boardId);
+
+		return ApiResponse.onSuccess(
+			SuccessStatus.GET_BOARD_STATS_SUCCESS,
+			BoardStatsResponseVo.boardStatsDtoToVo(boardStatsResponseDto)
+		);
+	}
+}

--- a/src/main/java/hobbiedo/batch/vo/response/BoardStatsResponseVo.java
+++ b/src/main/java/hobbiedo/batch/vo/response/BoardStatsResponseVo.java
@@ -1,0 +1,28 @@
+package hobbiedo.batch.vo.response;
+
+import hobbiedo.batch.dto.response.BoardStatsResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "게시판 통계 조회 응답")
+public class BoardStatsResponseVo {
+
+	private Integer commentCount; // 댓글 수
+	private Integer likeCount; // 좋아요 수
+
+	public BoardStatsResponseVo(Integer commentCount, Integer likeCount) {
+		this.commentCount = commentCount;
+		this.likeCount = likeCount;
+	}
+
+	public static BoardStatsResponseVo boardStatsDtoToVo(
+		BoardStatsResponseDto boardStatsResponseDto) {
+		return new BoardStatsResponseVo(
+			boardStatsResponseDto.getCommentCount(),
+			boardStatsResponseDto.getLikeCount()
+		);
+	}
+}

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -14,7 +14,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
 
 	// 게시글 통계 테이블이 존재하지 않을 경우
-	BOARD_STATS_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_STATS404", "게시글 통계 테이블이 존재하지 않습니다");
+	BOARD_STATS_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_STATS401", "게시글 통계 테이블이 존재하지 않습니다");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -11,7 +11,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 	VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "GLOBAL400", "데이터베이스 유효성 에러"),
-	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다");
+	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
+
+	// 게시글 통계 테이블이 존재하지 않을 경우
+	BOARD_STATS_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_STATS404", "게시글 통계 테이블이 존재하지 않습니다");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
@@ -10,7 +10,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SuccessStatus implements BaseCode {
-	EXAMPLE_EXCEPTION(HttpStatus.OK, "EXAMPLE200", "샘플 성공 메시지입니다.");
+	EXAMPLE_EXCEPTION(HttpStatus.OK, "EXAMPLE200", "샘플 성공 메시지입니다."),
+
+	// 게시글 통계 조회 성공
+	GET_BOARD_STATS_SUCCESS(HttpStatus.OK, "GET_BOARD_STATS_SUCCESS", "게시글 통계 조회 성공");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
@@ -13,7 +13,7 @@ public enum SuccessStatus implements BaseCode {
 	EXAMPLE_EXCEPTION(HttpStatus.OK, "EXAMPLE200", "샘플 성공 메시지입니다."),
 
 	// 게시글 통계 조회 성공
-	GET_BOARD_STATS_SUCCESS(HttpStatus.OK, "GET_BOARD_STATS_SUCCESS", "게시글 통계 조회 성공");
+	GET_BOARD_STATS_SUCCESS(HttpStatus.OK, "BOARD_STATS200", "게시글 통계 조회 성공");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/config/BatchConfig.java
+++ b/src/main/java/hobbiedo/global/config/BatchConfig.java
@@ -1,0 +1,66 @@
+package hobbiedo.global.config;
+
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import hobbiedo.batch.application.BoardStatsService;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class BatchConfig {
+
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
+	private final BoardStatsService boardStatsService;
+
+	// @Bean
+	// public Job boardStatsUpdateJob() {
+	// 	return new JobBuilder("boardStatsUpdateJob", jobRepository)
+	// 		.start(boardStatsUpdateStep())
+	// 		.build();
+	// }
+	//
+	// @Bean
+	// public Step boardStatsUpdateStep() {
+	// 	return new StepBuilder("boardStatsUpdateStep", jobRepository)
+	// 		.tasklet((contribution, chunkContext) -> {
+	// 			updateBoardStats();
+	// 			return RepeatStatus.FINISHED;
+	// 		})
+	// 		.transactionManager(transactionManager)
+	// 		.build();
+	// }
+	//
+	// private void updateBoardStats() {
+	// 	boardStatsService.updateBoardCommentStats();
+	// 	boardStatsService.updateBoardLikeStats();
+	// }
+	//
+	// @Bean
+	// public Tasklet boardStatsTasklet() {
+	// 	return new BoardStatsTasklet();
+	// }
+	//
+	// @Bean
+	// @StepScope
+	// public ItemReader<BoardStats> boardStatsReader() {
+	// 	// BoardStatsReader 구현 클래스 인스턴스 반환
+	// 	return new BoardStatsReader();
+	// }
+	//
+	// @Bean
+	// @StepScope
+	// public ItemProcessor<BoardStats, BoardStats> boardStatsProcessor() {
+	// 	// BoardStatsProcessor 구현 클래스 인스턴스 반환
+	// 	return new BoardStatsProcessor();
+	// }
+	//
+	// @Bean
+	// @StepScope
+	// public ItemWriter<BoardStats> boardStatsWriter() {
+	// 	// BoardStatsWriter 구현 클래스 인스턴스 반환
+	// 	return new BoardStatsWriter(boardStatsService);
+	// }
+}

--- a/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
@@ -108,7 +108,8 @@ public class KafkaConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> commentUpdateKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCommentUpdateDto> commentUpdateKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -137,7 +138,8 @@ public class KafkaConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> commentDeleteKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCommentUpdateDto> commentDeleteKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -166,7 +168,8 @@ public class KafkaConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> likeUpdateKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardLikeUpdateDto> likeUpdateKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -195,7 +198,8 @@ public class KafkaConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> likeDeleteKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardLikeUpdateDto> likeDeleteKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();

--- a/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
@@ -14,8 +14,10 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.batch.kafka.dto.BoardLikeUpdateDto;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -83,6 +85,122 @@ public class KafkaConsumerConfig {
 			new ConcurrentKafkaListenerContainerFactory<>();
 
 		factory.setConsumerFactory(deleteConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 통계 테이블 댓글 수 증가 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCommentUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCommentUpdateDto> commentUpdateConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCommentUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> commentUpdateKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(commentUpdateConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 통계 테이블 댓글 수 감소 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCommentUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCommentUpdateDto> commentDeleteConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCommentUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> commentDeleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(commentDeleteConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 통계 테이블 좋아요 수 증가 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardLikeUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardLikeUpdateDto> likeUpdateConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardLikeUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> likeUpdateKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(likeUpdateConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 통계 테이블 좋아요 수 감소 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardLikeUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardLikeUpdateDto> likeDeleteConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardLikeUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> likeDeleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardLikeUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(likeDeleteConsumerFactory());
 
 		return factory;
 	}


### PR DESCRIPTION
## 📣 게시글 댓글, 좋아요 업데이트 토픽 수신 시 통계 테이블 업데이트 기능 추가 및 댓글, 좋아요 수 조회 기능
### 📅 날짜 - 2024.06.17

### 🌵Branch
feature/update-for-board-stats  → develop

### 📢 Description
**1. 게시글 서비스에서 날아온 댓글, 좋아요 업데이트 토픽 메세지 수신 시 해당 토픽이 어떤 토픽인지 판단하고 대응하고 서비스 로직을 호출하고, 게시글 통계 테이블을 업데이트한다**
**2. 게시글 통계를 조회한다**


### 💬Issue Number
[#3 ] - 💫[FEAT] 게시글 댓글, 좋아요 업데이트 토픽 수신 시 통계 테이블 업데이트 기능 추가 및 댓글, 좋아요 수 조회 기능 #3

### 🛠️Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 컨슈머 설정을 해주었고, 토픽을 받아 각 서비스 로직으로 보내어 게시글 통계 데이턱 업데이트가 되는 것을 확인하였고, 테스트는 Swagger 를 통해 확인하였다
2. 주간 코드 리뷰 간에 스프링 배치 러닝 커브가 오래 걸릴 수 있으니 우선적으로 바로 통계 데이터를 업데이트 하게끔 하고 추후 스프링 배치를 적용하여 업데이트 하게끔 하라는 피드백에 따라 현재는 스프링 배치가 적용되어 있지 않다