### PR TITLE
[FEAT] 게시글 좋아요 수, 댓글 수 증가 또는 감소 시 토픽 발송 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -1,10 +1,10 @@
 package hobbiedo.batch.application;
 
 import hobbiedo.batch.dto.response.BoardStatsResponseDto;
-import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
-import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
-import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
-import hobbiedo.batch.kafka.dto.BoardLikeUpdateDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardCommentUpdateDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardCreateEventDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardDeleteEventDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardLikeUpdateDto;
 
 public interface BoardStatsService {
 

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
@@ -4,10 +4,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import hobbiedo.batch.application.BoardStatsService;
-import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
-import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
-import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
-import hobbiedo.batch.kafka.dto.BoardLikeUpdateDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardCommentUpdateDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardCreateEventDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardDeleteEventDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardLikeUpdateDto;
 import lombok.RequiredArgsConstructor;
 
 @Service

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaProducerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaProducerService.java
@@ -1,0 +1,71 @@
+package hobbiedo.batch.kafka.application;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import hobbiedo.batch.kafka.dto.producer.BoardCommentCountUpdateDto;
+import hobbiedo.batch.kafka.dto.producer.BoardLikeCountUpdateDto;
+
+@Service
+public class KafkaProducerService {
+
+	// 통계 게시글 댓글 수 증가 이벤트용 토픽
+	private static final String STATISTICS_BOARD_COMMENT_UPDATE_TOPIC = "statistics-board-comment-update-topic";
+
+	// 통계 게시글 댓글 수 감소 이벤트용 토픽
+	private static final String STATISTICS_BOARD_COMMENT_DELETE_TOPIC = "statistics-board-comment-delete-topic";
+
+	// 통계 게시글 좋아요 수 증가 이벤트용 토픽
+	private static final String STATISTICS_BOARD_LIKE_UPDATE_TOPIC = "statistics-board-like-update-topic";
+
+	// 통계 게시글 좋아요 수 감소 이벤트용 토픽
+	private static final String STATISTICS_BOARD_LIKE_DELETE_TOPIC = "statistics-board-like-delete-topic";
+
+	@Autowired
+	private KafkaTemplate<String, Object> kafkaTemplate;
+
+	// 통계 게시글 댓글 수 증가 이벤트 메시지 전송
+	public void sendUpdateCommentCountMessage(BoardCommentCountUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(STATISTICS_BOARD_COMMENT_UPDATE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 통계 게시글 댓글 수 감소 이벤트 메시지 전송
+	public void sendDeleteCommentCountMessage(BoardCommentCountUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(STATISTICS_BOARD_COMMENT_DELETE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 좋아요 수 증가 이벤트 메시지 전송
+	public void sendUpdateLikeCountMessage(BoardLikeCountUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(STATISTICS_BOARD_LIKE_UPDATE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 좋아요 수 감소 이벤트 메시지 전송
+	public void sendDeleteLikeCountMessage(BoardLikeCountUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(STATISTICS_BOARD_LIKE_DELETE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCommentUpdateDto.java
@@ -1,0 +1,16 @@
+package hobbiedo.batch.kafka.dto.consumer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCommentUpdateDto {
+
+	private Long boardId;
+	private Integer commentCount;
+}

--- a/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCreateEventDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCreateEventDto.java
@@ -1,4 +1,4 @@
-package hobbiedo.batch.kafka.dto;
+package hobbiedo.batch.kafka.dto.consumer;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardDeleteEventDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardDeleteEventDto.java
@@ -1,4 +1,4 @@
-package hobbiedo.batch.kafka.dto;
+package hobbiedo.batch.kafka.dto.consumer;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardLikeUpdateDto.java
@@ -1,4 +1,4 @@
-package hobbiedo.batch.kafka.dto;
+package hobbiedo.batch.kafka.dto.consumer;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/hobbiedo/batch/kafka/dto/producer/BoardCommentCountUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/producer/BoardCommentCountUpdateDto.java
@@ -1,4 +1,4 @@
-package hobbiedo.batch.kafka.dto;
+package hobbiedo.batch.kafka.dto.producer;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardCommentUpdateDto {
+public class BoardCommentCountUpdateDto {
 
 	private Long boardId;
 	private Integer commentCount;

--- a/src/main/java/hobbiedo/batch/kafka/dto/producer/BoardLikeCountUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/producer/BoardLikeCountUpdateDto.java
@@ -1,0 +1,16 @@
+package hobbiedo.batch.kafka.dto.producer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardLikeCountUpdateDto {
+
+	private Long boardId;
+	private Integer likeCount;
+}

--- a/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
@@ -14,10 +14,10 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
-import hobbiedo.batch.kafka.dto.BoardCommentUpdateDto;
-import hobbiedo.batch.kafka.dto.BoardCreateEventDto;
-import hobbiedo.batch.kafka.dto.BoardDeleteEventDto;
-import hobbiedo.batch.kafka.dto.BoardLikeUpdateDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardCommentUpdateDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardCreateEventDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardDeleteEventDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardLikeUpdateDto;
 import lombok.RequiredArgsConstructor;
 
 @Configuration

--- a/src/main/java/hobbiedo/global/config/KafkaProducerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaProducerConfig.java
@@ -1,0 +1,43 @@
+package hobbiedo.global.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+	// 카프카 주소
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers; // static 제거
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory() {
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+			JsonSerializer.class); // JsonSerializer 사용함으로써 객체 JSON 으로 변환
+
+		return new DefaultKafkaProducerFactory<>(configProps);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}


### PR DESCRIPTION
## 📣 게시글 좋아요 수, 댓글 수 증가 또는 감소 시 토픽 발송 기능 추가
### 📅 날짜 -  2024.06.21

### 🌵Branch
feature/board-stats-update-topic-publish  → develop

### 📢 Description
**게시글 통계 테이블에서 댓글 수와 좋아요 수가 증가 또는 감소가 되면 트리거가 되어 해당되는 토픽을 발송한다**

### 💬Issue Number
[#8 ] - 💫[FEAT] 게시글 좋아요 수, 댓글 수 증가 또는 감소 시 토픽 발송 기능 추가 #8

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. Swagger 와 offset explorer 를 통해 게시글 통계 업데이트 토픽이 발송되는 것을 확인하였다
2. 기존에 컨슈머 설정만 있었던 것에서 프로듀서 설정을 추가하였다