### PR TITLE
[REFACTOR] 게시글 댓글 작성, 삭제 컨슈머 토픽 데이터 필드 수정

### DIFF
--- a/src/main/java/hobbiedo/batch/application/BoardStatsService.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsService.java
@@ -1,6 +1,7 @@
 package hobbiedo.batch.application;
 
 import hobbiedo.batch.dto.response.BoardStatsResponseDto;
+import hobbiedo.batch.kafka.dto.consumer.BoardCommentDeleteDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardDeleteEventDto;
@@ -14,7 +15,7 @@ public interface BoardStatsService {
 
 	void updateBoardCommentStats(BoardCommentUpdateDto eventDto);
 
-	void deleteBoardCommentStats(BoardCommentUpdateDto eventDto);
+	void deleteBoardCommentStats(BoardCommentDeleteDto eventDto);
 
 	void updateBoardLikeStats(BoardLikeUpdateDto eventDto);
 

--- a/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
+++ b/src/main/java/hobbiedo/batch/application/BoardStatsServiceImpl.java
@@ -9,6 +9,7 @@ import hobbiedo.batch.domain.BoardStats;
 import hobbiedo.batch.dto.response.BoardStatsResponseDto;
 import hobbiedo.batch.infrastructure.BoardStatsRepository;
 import hobbiedo.batch.kafka.application.KafkaProducerService;
+import hobbiedo.batch.kafka.dto.consumer.BoardCommentDeleteDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardDeleteEventDto;
@@ -105,7 +106,7 @@ public class BoardStatsServiceImpl implements BoardStatsService {
 	 */
 	@Override
 	@Transactional
-	public void deleteBoardCommentStats(BoardCommentUpdateDto eventDto) {
+	public void deleteBoardCommentStats(BoardCommentDeleteDto eventDto) {
 
 		BoardStats boardStats = boardStatsRepository.findByBoardId(eventDto.getBoardId())
 			.orElseThrow(() -> new BatchExceptionHandler(BOARD_STATS_NOT_FOUND));

--- a/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/batch/kafka/application/KafkaConsumerService.java
@@ -4,6 +4,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import hobbiedo.batch.application.BoardStatsService;
+import hobbiedo.batch.kafka.dto.consumer.BoardCommentDeleteDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardDeleteEventDto;
@@ -55,7 +56,7 @@ public class KafkaConsumerService {
 	 */
 	@KafkaListener(topics = "board-comment-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
 		containerFactory = "commentDeleteKafkaListenerContainerFactory")
-	public void listenToBoardCommentDeleteTopic(BoardCommentUpdateDto eventDto) {
+	public void listenToBoardCommentDeleteTopic(BoardCommentDeleteDto eventDto) {
 
 		boardStatsService.deleteBoardCommentStats(eventDto);
 	}

--- a/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCommentDeleteDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCommentDeleteDto.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardLikeUpdateDto {
+public class BoardCommentDeleteDto {
 
 	private Long boardId;
+	private Long commentId;
 }

--- a/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/batch/kafka/dto/consumer/BoardCommentUpdateDto.java
@@ -1,5 +1,7 @@
 package hobbiedo.batch.kafka.dto.consumer;
 
+import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +13,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class BoardCommentUpdateDto {
 
-	private Long boardId;
-	private Integer commentCount;
+	private Long boardId; // 게시글 번호
+	private Long commentId; // 댓글 번호
+	private String writerUuid; // 작성자 uuid
+	private String content; // 댓글 내용
+	private Boolean isInCrew; // 소모임 회원 여부
+	private LocalDateTime createdAt; // 작성일
 }

--- a/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaConsumerConfig.java
@@ -14,6 +14,7 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+import hobbiedo.batch.kafka.dto.consumer.BoardCommentDeleteDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCommentUpdateDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardCreateEventDto;
 import hobbiedo.batch.kafka.dto.consumer.BoardDeleteEventDto;
@@ -121,10 +122,10 @@ public class KafkaConsumerConfig {
 
 	/**
 	 * 게시글 통계 테이블 댓글 수 감소 이벤트용 ConsumerFactory
-	 * @return ConsumerFactory<String, BoardCommentUpdateDto>
+	 * @return ConsumerFactory<String, BoardCommentDeleteDto>
 	 */
 	@Bean
-	public ConsumerFactory<String, BoardCommentUpdateDto> commentDeleteConsumerFactory() {
+	public ConsumerFactory<String, BoardCommentDeleteDto> commentDeleteConsumerFactory() {
 
 		Map<String, Object> configProps = new HashMap<>();
 		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -134,14 +135,14 @@ public class KafkaConsumerConfig {
 		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
 
 		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
-			new JsonDeserializer<>(BoardCommentUpdateDto.class, false));
+			new JsonDeserializer<>(BoardCommentDeleteDto.class, false));
 	}
 
 	@Bean
 	public ConcurrentKafkaListenerContainerFactory<String,
-		BoardCommentUpdateDto> commentDeleteKafkaListenerContainerFactory() {
+		BoardCommentDeleteDto> commentDeleteKafkaListenerContainerFactory() {
 
-		ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> factory =
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentDeleteDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
 
 		factory.setConsumerFactory(commentDeleteConsumerFactory());


### PR DESCRIPTION
## 📣 게시글 댓글 작성, 삭제 컨슈머 토픽 데이터 필드 수정
### 📅 날짜 -  2024.06.22

### 🌵Branch
feature/modify-comment-consumer-topic-fields  → develp[

### 📢 Description
**게시글 서비스에서 날아오는 댓글 생성, 삭제 컨슈머 토픽 내 데이터 필드 형식을 수정한다**

### 💬Issue Number
[#10 ] - ♻️[REFACTOR] 게시글 댓글 작성, 삭제 컨슈머 토픽 데이터 필드 수정 #10

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 게시글 댓글, 생성 토픽 감지 시 댓글 수가 정상적으로 업데이트 되는 것을 확인하였다
2. 게시글 댓글 수 증가, 감소 시 해당 토픽도 잘 발송되는 것을 확인하였다